### PR TITLE
Added include <memory> to parser.hh in order to use shared_ptr

### DIFF
--- a/parser.hh
+++ b/parser.hh
@@ -32,6 +32,7 @@
 #include <string>
 #include <list>
 #include <functional>
+#include <memory>
 
 
 namespace pegmatite {


### PR DESCRIPTION
In the `parser.hh` file, the `shared_ptr` data type is used, which is provided by the header file `memory` of the standard template library. However, `parser.hh` does not include `memory`, which causes compilation to fail with both GCC and clang; with the added `include`, the library compiles with clang. (But not with GCC, for some reason.)
