### PR TITLE
Get Pegmatite building with GCC 4.9.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(pegmatite-static PROPERTIES
 	POSITION_INDEPENDENT_CODE true
 	OUTPUT_NAME "pegmatite")
 
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra")
 option(USE_RTTI "Use native C++ RTTI" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 if (USE_RTTI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(pegmatite-static PROPERTIES
 	POSITION_INDEPENDENT_CODE true
 	OUTPUT_NAME "pegmatite")
 
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra")
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wall")
 option(USE_RTTI "Use native C++ RTTI" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 if (USE_RTTI)

--- a/parser.cc
+++ b/parser.cc
@@ -487,6 +487,11 @@ class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Ou
 			--s;
 			return *this;
 		}
+		inline IteratorAdaptor<Src, Out,In> &operator++(int)
+		{
+			s++;
+			return *this;
+		}
 		inline bool operator==(const IteratorAdaptor<Src, Out,In> &other) const
 		{
 			return s == other.s;

--- a/parser.cc
+++ b/parser.cc
@@ -147,7 +147,7 @@ CharacterExprPtr operator "" _E(const char x)
 {
 	return CharacterExprPtr(new CharacterExpr(x));
 }
-ExprPtr operator "" _S(const char *x, std::size_t len)
+ExprPtr operator "" _S(const char *x, std::size_t)
 {
 	return set(x);
 }
@@ -1082,14 +1082,14 @@ public:
 	DebugExpr(std::function<void()> f) : fn(f) {}
 
 	//parse with whitespace
-	virtual bool parse_non_term(Context &con) const
+	virtual bool parse_non_term(Context &) const
 	{
 		fn();
 		return true;
 	}
 
 	//parse terminal
-	virtual bool parse_term(Context &con) const
+	virtual bool parse_term(Context &) const
 	{
 		fn();
 		return true;
@@ -1174,7 +1174,7 @@ bool Context::parse_rule(const Rule &r, bool (Context::*parse_func)(const Rule &
 	}
 
 	// Return value (success or failure of parse)
-	bool ok;
+	bool ok = false;
 
 	// Compute the new position in the stream.  We're only tracking offsets to
 	// detect left recursion, not storing iterators.

--- a/parser.cc
+++ b/parser.cc
@@ -482,14 +482,14 @@ class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Ou
 			++s;
 			return *this;
 		}
+		inline IteratorAdaptor<Src, Out,In> &operator++(int inc)
+		{
+			s += inc;
+			return *this;
+		}
 		inline IteratorAdaptor<Src, Out,In> &operator--()
 		{
 			--s;
-			return *this;
-		}
-		inline IteratorAdaptor<Src, Out,In> &operator++(int)
-		{
-			s++;
 			return *this;
 		}
 		inline bool operator==(const IteratorAdaptor<Src, Out,In> &other) const
@@ -1174,7 +1174,7 @@ bool Context::parse_rule(const Rule &r, bool (Context::*parse_func)(const Rule &
 	}
 
 	// Return value (success or failure of parse)
-	bool ok = false;
+	bool ok;
 
 	// Compute the new position in the stream.  We're only tracking offsets to
 	// detect left recursion, not storing iterators.

--- a/parser.hh
+++ b/parser.hh
@@ -661,7 +661,7 @@ inline ExprPtr trace(const char *msg, const ExprPtr e)
 	return trace_debug(msg, e);
 }
 #else
-inline ExprPtr trace(const char *msg, const ExprPtr e)
+inline ExprPtr trace(const char *, const ExprPtr e)
 {
 	return e;
 }

--- a/parser.hh
+++ b/parser.hh
@@ -101,9 +101,9 @@ class Input
 			idx++;
 			return *this;
 		}
-	        inline iterator &operator++(int)
+	        inline iterator &operator++(int inc)
 		{
-			idx++;
+			idx += inc;
 			return *this;
 		}
 		/**

--- a/parser.hh
+++ b/parser.hh
@@ -101,6 +101,11 @@ class Input
 			idx++;
 			return *this;
 		}
+	        inline iterator &operator++(int)
+		{
+			idx++;
+			return *this;
+		}
 		/**
 		 * Move the iterator forward by the specified amount.
 		 */


### PR DESCRIPTION
Without this patch, I get the following build error,

```
$ make
Scanning dependencies of target pegmatite
[ 25%] Building CXX object CMakeFiles/pegmatite.dir/ast.cc.o
[ 50%] Building CXX object CMakeFiles/pegmatite.dir/parser.cc.o
In file included from /usr/include/c++/4.9/bits/regex_executor.h:167:0,
                 from /usr/include/c++/4.9/regex:61,
                 from /home/charlie/src/Pegmatite/parser.cc:32:
/usr/include/c++/4.9/bits/regex_executor.tcc: In instantiation of ‘bool std::__detail::_Executor< <template-parameter-1-1>, <template-parameter-1-2>, <template-parameter-1-3>, <anonymous> >::_M_search() [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _TraitsT = std::regex_traits<wchar_t>; bool __dfs_mode = false]’:
/usr/include/c++/4.9/bits/regex.tcc:94:12:   required from ‘bool std::__detail::__regex_algo_impl(_BiIter, _BiIter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _CharT = wchar_t; _TraitsT = std::regex_traits<wchar_t>; std::__detail::_RegexExecutorPolicy __policy = (std::__detail::_RegexExecutorPolicy)0; bool __match_mode = false]’
/usr/include/c++/4.9/bits/regex.h:2125:33:   required from ‘bool std::regex_search(_Bi_iter, _Bi_iter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _Bi_iter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _Ch_type = wchar_t; _Rx_traits = std::regex_traits<wchar_t>]’
/home/charlie/src/Pegmatite/parser.cc:523:78:   required from ‘bool {anonymous}::regexMatch(pegmatite::Input::iterator, pegmatite::Input::iterator, const std::basic_regex<T>&, size_t&) [with T = wchar_t; size_t = long unsigned int]’
/home/charlie/src/Pegmatite/parser.cc:541:56:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse(pegmatite::Context&) const [with CharTy = wchar_t]’
/home/charlie/src/Pegmatite/parser.cc:555:19:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse_non_term(pegmatite::Context&) const [with CharTy = wchar_t]’
/home/charlie/src/Pegmatite/parser.cc:1746:1:   required from here
/usr/include/c++/4.9/bits/regex_executor.tcc:52:19: error: no ‘operator++(int)’ declared for postfix ‘++’ [-fpermissive]
       while (__cur++ != _M_end);
                   ^
/usr/include/c++/4.9/bits/regex_executor.tcc: In instantiation of ‘bool std::__detail::_Executor< <template-parameter-1-1>, <template-parameter-1-2>, <template-parameter-1-3>, <anonymous> >::_M_search() [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _TraitsT = std::regex_traits<wchar_t>; bool __dfs_mode = true]’:
/usr/include/c++/4.9/bits/regex.tcc:103:12:   required from ‘bool std::__detail::__regex_algo_impl(_BiIter, _BiIter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _CharT = wchar_t; _TraitsT = std::regex_traits<wchar_t>; std::__detail::_RegexExecutorPolicy __policy = (std::__detail::_RegexExecutorPolicy)0; bool __match_mode = false]’
/usr/include/c++/4.9/bits/regex.h:2125:33:   required from ‘bool std::regex_search(_Bi_iter, _Bi_iter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _Bi_iter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, wchar_t, char32_t> > >; _Ch_type = wchar_t; _Rx_traits = std::regex_traits<wchar_t>]’
/home/charlie/src/Pegmatite/parser.cc:523:78:   required from ‘bool {anonymous}::regexMatch(pegmatite::Input::iterator, pegmatite::Input::iterator, const std::basic_regex<T>&, size_t&) [with T = wchar_t; size_t = long unsigned int]’
/home/charlie/src/Pegmatite/parser.cc:541:56:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse(pegmatite::Context&) const [with CharTy = wchar_t]’
/home/charlie/src/Pegmatite/parser.cc:555:19:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse_non_term(pegmatite::Context&) const [with CharTy = wchar_t]’
/home/charlie/src/Pegmatite/parser.cc:1746:1:   required from here
/usr/include/c++/4.9/bits/regex_executor.tcc:52:19: error: no ‘operator++(int)’ declared for postfix ‘++’ [-fpermissive]
/usr/include/c++/4.9/bits/regex_executor.tcc: In instantiation of ‘bool std::__detail::_Executor< <template-parameter-1-1>, <template-parameter-1-2>, <template-parameter-1-3>, <anonymous> >::_M_search() [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _TraitsT = std::regex_traits<char>; bool __dfs_mode = false]’:
/usr/include/c++/4.9/bits/regex.tcc:94:12:   required from ‘bool std::__detail::__regex_algo_impl(_BiIter, _BiIter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _CharT = char; _TraitsT = std::regex_traits<char>; std::__detail::_RegexExecutorPolicy __policy = (std::__detail::_RegexExecutorPolicy)0; bool __match_mode = false]’
/usr/include/c++/4.9/bits/regex.h:2125:33:   required from ‘bool std::regex_search(_Bi_iter, _Bi_iter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _Bi_iter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _Ch_type = char; _Rx_traits = std::regex_traits<char>]’
/home/charlie/src/Pegmatite/parser.cc:523:78:   required from ‘bool {anonymous}::regexMatch(pegmatite::Input::iterator, pegmatite::Input::iterator, const std::basic_regex<T>&, size_t&) [with T = char; size_t = long unsigned int]’
/home/charlie/src/Pegmatite/parser.cc:541:56:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse(pegmatite::Context&) const [with CharTy = char]’
/home/charlie/src/Pegmatite/parser.cc:555:19:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse_non_term(pegmatite::Context&) const [with CharTy = char]’
/home/charlie/src/Pegmatite/parser.cc:1746:1:   required from here
/usr/include/c++/4.9/bits/regex_executor.tcc:52:19: error: no ‘operator++(int)’ declared for postfix ‘++’ [-fpermissive]
/usr/include/c++/4.9/bits/regex_executor.tcc: In instantiation of ‘bool std::__detail::_Executor< <template-parameter-1-1>, <template-parameter-1-2>, <template-parameter-1-3>, <anonymous> >::_M_search() [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _TraitsT = std::regex_traits<char>; bool __dfs_mode = true]’:
/usr/include/c++/4.9/bits/regex.tcc:103:12:   required from ‘bool std::__detail::__regex_algo_impl(_BiIter, _BiIter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _BiIter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _CharT = char; _TraitsT = std::regex_traits<char>; std::__detail::_RegexExecutorPolicy __policy = (std::__detail::_RegexExecutorPolicy)0; bool __match_mode = false]’
/usr/include/c++/4.9/bits/regex.h:2125:33:   required from ‘bool std::regex_search(_Bi_iter, _Bi_iter, std::match_results<_BiIter, _Alloc>&, const std::basic_regex<_CharT, _TraitsT>&, std::regex_constants::match_flag_type) [with _Bi_iter = {anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t>; _Alloc = std::allocator<std::sub_match<{anonymous}::IteratorAdaptor<pegmatite::Input::iterator, char, char32_t> > >; _Ch_type = char; _Rx_traits = std::regex_traits<char>]’
/home/charlie/src/Pegmatite/parser.cc:523:78:   required from ‘bool {anonymous}::regexMatch(pegmatite::Input::iterator, pegmatite::Input::iterator, const std::basic_regex<T>&, size_t&) [with T = char; size_t = long unsigned int]’
/home/charlie/src/Pegmatite/parser.cc:541:56:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse(pegmatite::Context&) const [with CharTy = char]’
/home/charlie/src/Pegmatite/parser.cc:555:19:   required from ‘bool {anonymous}::RegexExpr<CharTy>::parse_non_term(pegmatite::Context&) const [with CharTy = char]’
/home/charlie/src/Pegmatite/parser.cc:1746:1:   required from here
/usr/include/c++/4.9/bits/regex_executor.tcc:52:19: error: no ‘operator++(int)’ declared for postfix ‘++’ [-fpermissive]
CMakeFiles/pegmatite.dir/build.make:77: recipe for target 'CMakeFiles/pegmatite.dir/parser.cc.o' failed
make[2]: *** [CMakeFiles/pegmatite.dir/parser.cc.o] Error 1
CMakeFiles/Makefile2:60: recipe for target 'CMakeFiles/pegmatite.dir/all' failed
make[1]: *** [CMakeFiles/pegmatite.dir/all] Error 2
Makefile:76: recipe for target 'all' failed
make: *** [all] Error 2
```