### PR TITLE
Fix appending to CMAKE_CXX_FLAGS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(pegmatite-static PROPERTIES
 	POSITION_INDEPENDENT_CODE true
 	OUTPUT_NAME "pegmatite")
 
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 option(USE_RTTI "Use native C++ RTTI" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 if (USE_RTTI)


### PR DESCRIPTION
CMAKE_CXX_FLAGS is a string, not a list, so we need to append to it with
the `set(X "${X} new_stuff")` idiom rather than `list(APPEND ...)`, which
joins strings with a semicolon instead of a space. Using the `list`
function together with user-specified flags results in:

```
$ cmake -D CMAKE_CXX_FLAGS="-Weverything" -G Ninja ..
[...]
$ ninja
[...]
FAILED: /usr/bin/CC   -DUSE_RTTI=1 -Dpegmatite_EXPORTS -Weverything;-std=c++11
```