### PR TITLE
Fix iterator post-increment operators.

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -482,10 +482,11 @@ class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Ou
 			++s;
 			return *this;
 		}
-		inline IteratorAdaptor<Src, Out,In> &operator++(int inc)
+		inline IteratorAdaptor<Src, Out,In> operator++(int inc)
 		{
-			s += inc;
-			return *this;
+			auto copy = *this;
+			s++;
+			return copy;
 		}
 		inline IteratorAdaptor<Src, Out,In> &operator--()
 		{

--- a/parser.hh
+++ b/parser.hh
@@ -101,10 +101,11 @@ class Input
 			idx++;
 			return *this;
 		}
-	        inline iterator &operator++(int inc)
+	        inline iterator operator++(int /* dummy */)
 		{
-			idx += inc;
-			return *this;
+			iterator copy = *this;
+			idx++;
+			return copy;
 		}
 		/**
 		 * Move the iterator forward by the specified amount.


### PR DESCRIPTION
The post-increment operators in various iterators didn't conform to the C++
standard (and, in fact, I'm not sure how they ever worked!). This required
two fixes.

First: according to section [over.inc], the post-increment operator's
parameter only exists to differentiate between pre- and post-increment,
and compliant compilers should only generate calls to it with the argument
0. Calling the method manually, e.g., `i++(42)` should still only
increment the iterator once. So, the current implementation, when called by
a compiler-generated expation of `i++`, won't even increment the iterator!

Also, post-increment operators should return a copy of the iterator from
*before* the increment was performed, not a reference to an incremented
iterator. Otherwise, `i++` would be equivalent to `++i`.