### PR TITLE
Add a StreamInput to Pegmatite.

### DIFF
--- a/parser.hh
+++ b/parser.hh
@@ -304,6 +304,22 @@ struct AsciiFileInput : public Input
 	size_t file_size;
 };
 
+/** An Input that wraps a std::istream. */
+struct StreamInput : public Input
+{
+	public:
+	static StreamInput Create(std::istream&);
+
+	bool fillBuffer(Index start, Index &length, char32_t*&) override;
+	Index size() const override;
+
+	private:
+	StreamInput(std::istream&, size_t len);
+
+	const size_t length;
+	std::istream& stream;
+};
+
 /**
  * A concrete Input subclass that wraps a std::string, providing access to the
  * underlying characters.

--- a/parser.hh
+++ b/parser.hh
@@ -309,7 +309,8 @@ struct StreamInput : public Input
 {
 	/**
 	 * Construct a StreamInput from a std::istream.
-	 * Makes no assumptions about the current position of the stream.
+	 * Makes no assumptions about the current position of the stream,
+	 * but it must be seekable.
 	 */
 	static StreamInput Create(std::istream&);
 

--- a/parser.hh
+++ b/parser.hh
@@ -308,6 +308,10 @@ struct AsciiFileInput : public Input
 struct StreamInput : public Input
 {
 	public:
+	/**
+	 * Construct a StreamInput from a std::istream.
+	 * Makes no assumptions about the current position of the stream.
+	 */
 	static StreamInput Create(std::istream&);
 
 	bool fillBuffer(Index start, Index &length, char32_t*&) override;

--- a/parser.hh
+++ b/parser.hh
@@ -307,7 +307,6 @@ struct AsciiFileInput : public Input
 /** An Input that wraps a std::istream. */
 struct StreamInput : public Input
 {
-	public:
 	/**
 	 * Construct a StreamInput from a std::istream.
 	 * Makes no assumptions about the current position of the stream.

--- a/parser.hh
+++ b/parser.hh
@@ -307,10 +307,14 @@ struct AsciiFileInput : public Input
 /** An Input that wraps a std::istream. */
 struct StreamInput : public Input
 {
+	public:
 	/**
-	 * Construct a StreamInput from a std::istream.
-	 * Makes no assumptions about the current position of the stream,
-	 * but it must be seekable.
+	 * Create a StreamInput from a std::istream.
+	 *
+	 * The stream (which may start at any position) must be seekable.
+	 * The StreamInput object will share the referenced std::istream,
+	 * advancing its position until parsing is complete. Premature
+	 * stream closure will cause parsing errors.
 	 */
 	static StreamInput Create(std::istream&);
 


### PR DESCRIPTION
Allow parsing from a std::istream. This unfortunately requires seeking to
the end and then back again, because Pegmatite wants to know how big the
stream is, but that's probably acceptable in our current use cases.