### PR TITLE
Add names (usually filenames) to Input.

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -1378,6 +1378,22 @@ char32_t Input::slowCharacterLookup(Index n)
 	return buffer[n - buffer_start];
 }
 Input::~Input() {}
+
+class NoInput : public Input
+{
+public:
+	NoInput() : Input("<none>") {}
+
+	bool fillBuffer(Index, Index&, char32_t*&) override { return false; }
+	Index size() const override { return 0; }
+};
+
+const Input& Input::iterator::input() const
+{
+	static NoInput None;
+	return buffer ? *buffer : None;
+}
+
 bool  UnicodeVectorInput::fillBuffer(Index start, Index &length, char32_t *&b)
 {
 	if (start > vector.size())
@@ -1459,7 +1475,6 @@ Input::Index AsciiFileInput::size() const
  */
 ParserPosition::ParserPosition(Input &i) :
 	it(i.begin()),
-	filename(i.name()),
 	line(1),
 	col(1)
 {

--- a/parser.cc
+++ b/parser.cc
@@ -1423,7 +1423,7 @@ Input::Index StringInput::size() const
 	return str.size();
 }
 
-AsciiFileInput::AsciiFileInput(const std::string& name, int file)
+AsciiFileInput::AsciiFileInput(int file, const std::string& name)
 	: Input(name), fd(file)
 {
 	struct stat buf;

--- a/parser.cc
+++ b/parser.cc
@@ -1379,19 +1379,10 @@ char32_t Input::slowCharacterLookup(Index n)
 }
 Input::~Input() {}
 
-class NoInput : public Input
+const std::string& Input::iterator::filename() const
 {
-public:
-	NoInput() : Input("<none>") {}
-
-	bool fillBuffer(Index, Index&, char32_t*&) override { return false; }
-	Index size() const override { return 0; }
-};
-
-const Input& Input::iterator::input() const
-{
-	static NoInput None;
-	return buffer ? *buffer : None;
+	static std::string None("<invalid input>");
+	return buffer ? buffer->name() : None;
 }
 
 bool  UnicodeVectorInput::fillBuffer(Index start, Index &length, char32_t *&b)

--- a/parser.cc
+++ b/parser.cc
@@ -1432,7 +1432,7 @@ Input::Index StringInput::size() const
 	return str.size();
 }
 
-AsciiFileInput::AsciiFileInput(std::string name, int file)
+AsciiFileInput::AsciiFileInput(const std::string& name, int file)
 	: Input(name), fd(file)
 {
 	struct stat buf;

--- a/parser.cc
+++ b/parser.cc
@@ -1416,7 +1416,8 @@ Input::Index StringInput::size() const
 	return str.size();
 }
 
-AsciiFileInput::AsciiFileInput(int file) : fd(file)
+AsciiFileInput::AsciiFileInput(std::string name, int file)
+	: Input(name), fd(file)
 {
 	struct stat buf;
 	if (fstat(fd, &buf) != 0)
@@ -1458,6 +1459,7 @@ Input::Index AsciiFileInput::size() const
  */
 ParserPosition::ParserPosition(Input &i) :
 	it(i.begin()),
+	filename(i.name()),
 	line(1),
 	col(1)
 {

--- a/parser.hh
+++ b/parser.hh
@@ -289,7 +289,7 @@ class UnicodeVectorInput : public Input
 	 * Constructs the wrapper from a vector.  
 	 * The new object takes ownership of the character data in the vector.
 	 */
-	UnicodeVectorInput(const std::string& name, std::vector<char32_t> &&v)
+	UnicodeVectorInput(std::vector<char32_t> &&v, const std::string& name = "")
 		: Input(name), vector(v) {}
 	/**
 	 * Provides direct access to the underlying vector's storage.
@@ -312,7 +312,7 @@ struct AsciiFileInput : public Input
 	/**
 	 * Construct a parser input from a specified file descriptor.
 	 */
-	AsciiFileInput(const std::string& name, int file);
+	AsciiFileInput(int file, const std::string& name = "");
 	bool  fillBuffer(Index start, Index &length, char32_t *&b) override;
 	Index size() const override;
 	private:
@@ -347,13 +347,13 @@ class StringInput : public Input
 	 * Constructs the wrapper from a string (`s`).  
 	 * The new object takes ownership of the character data in the string.
 	 */
-	StringInput(const std::string& name, std::string &&s)
+	StringInput(std::string &&s, const std::string& name = "")
 		: Input(name), str(s) {}
 	/**
 	 * Constructs the wrapper from a string (`s`).
 	 * The new object is copy-constructed from the string argument.
 	 */
-	StringInput(const std::string& name, const std::string& s)
+	StringInput(const std::string& s, const std::string& name = "")
 		: Input(name), str(s) {}
 	/**
 	 * Provides direct access to the underlying string's storage.
@@ -380,7 +380,7 @@ class IteratorInput : public Input
 	/**
 	 * Construct an input that reads from between the two iterators specified.
 	 */
-	IteratorInput(const std::string& name, T b, T e)
+	IteratorInput(T b, T e, const std::string& name = "")
 		: Input(name), begin(b), end(e) {}
 	/**
 	 * Copy the data into the buffer.

--- a/parser.hh
+++ b/parser.hh
@@ -205,6 +205,8 @@ class Input
 	 * Default constructor, sets the buffer start to be after the buffer end,
 	 * so that the first request will trigger a fetch from the underlying
 	 * storage.
+	 *
+	 * @param name    user-meaningful input name (typically a filename)
 	 */
 	Input(std::string name)
 		: user_name(name), buffer(0), buffer_start(1), buffer_end(0) {}

--- a/parser.hh
+++ b/parser.hh
@@ -87,10 +87,11 @@ class Input
 		 */
 		inline iterator() : buffer(0), idx(npos) {}
 		/**
-		 * Reference to the Input we were derived from.
-		 * Could be the "none" input.
+		 * Filename given by Input this iterator is derived from.
+		 * Typically a real filename, but not guaranteed (e.g., could
+		 * be "-" when input is derived from stdin).
 		 */
-		const Input& input() const;
+		const std::string& filename() const;
 		/**
 		 * Dereference operator, returns the character represented by this
 		 * index.
@@ -413,7 +414,7 @@ struct ParserPosition
 	Input::iterator it;
 
 	///user-meaningful filename.
-	const std::string& filename() const { return it.input().name(); }
+	const std::string& filename() const { return it.filename(); }
 
 	///line.
 	int line;

--- a/parser.hh
+++ b/parser.hh
@@ -215,7 +215,7 @@ class Input
 	 * A user-meaningful name.
 	 * This will typically be a filename, but it doesn't have to be.
 	 */
-	std::string	user_name;
+	const std::string	user_name;
 	/**
 	 * A pointer to the start of the buffer.  This must be a contiguous block
 	 * of memory, storing 32-bit characters.

--- a/parser.hh
+++ b/parser.hh
@@ -413,7 +413,7 @@ struct ParserPosition
 	Input::iterator it;
 
 	///user-meaningful filename.
-	std::string filename() const { return it.input().name(); }
+	const std::string& filename() const { return it.input().name(); }
 
 	///line.
 	int line;

--- a/parser.hh
+++ b/parser.hh
@@ -208,7 +208,7 @@ class Input
 	 *
 	 * @param name    user-meaningful input name (typically a filename)
 	 */
-	Input(std::string name)
+	Input(const std::string& name)
 		: user_name(name), buffer(0), buffer_start(1), buffer_end(0) {}
 	private:
 	/**

--- a/parser.hh
+++ b/parser.hh
@@ -87,6 +87,11 @@ class Input
 		 */
 		inline iterator() : buffer(0), idx(npos) {}
 		/**
+		 * Reference to the Input we were derived from.
+		 * Could be the "none" input.
+		 */
+		const Input& input() const;
+		/**
 		 * Dereference operator, returns the character represented by this
 		 * index.
 		 */
@@ -407,7 +412,7 @@ struct ParserPosition
 	Input::iterator it;
 
 	///user-meaningful filename.
-	std::string filename;
+	std::string filename() const { return it.input().name(); }
 
 	///line.
 	int line;

--- a/parser.hh
+++ b/parser.hh
@@ -288,7 +288,7 @@ class UnicodeVectorInput : public Input
 	 * Constructs the wrapper from a vector.  
 	 * The new object takes ownership of the character data in the vector.
 	 */
-	UnicodeVectorInput(std::string name, std::vector<char32_t> &&v)
+	UnicodeVectorInput(const std::string& name, std::vector<char32_t> &&v)
 		: Input(name), vector(v) {}
 	/**
 	 * Provides direct access to the underlying vector's storage.
@@ -311,7 +311,7 @@ struct AsciiFileInput : public Input
 	/**
 	 * Construct a parser input from a specified file descriptor.
 	 */
-	AsciiFileInput(std::string name, int file);
+	AsciiFileInput(const std::string& name, int file);
 	bool  fillBuffer(Index start, Index &length, char32_t *&b) override;
 	Index size() const override;
 	private:
@@ -346,12 +346,13 @@ class StringInput : public Input
 	 * Constructs the wrapper from a string (`s`).  
 	 * The new object takes ownership of the character data in the string.
 	 */
-	StringInput(std::string name, std::string &&s) : Input(name), str(s) {}
+	StringInput(const std::string& name, std::string &&s)
+		: Input(name), str(s) {}
 	/**
 	 * Constructs the wrapper from a string (`s`).
 	 * The new object is copy-constructed from the string argument.
 	 */
-	StringInput(std::string name, const std::string& s)
+	StringInput(const std::string& name, const std::string& s)
 		: Input(name), str(s) {}
 	/**
 	 * Provides direct access to the underlying string's storage.
@@ -378,7 +379,7 @@ class IteratorInput : public Input
 	/**
 	 * Construct an input that reads from between the two iterators specified.
 	 */
-	IteratorInput(std::string name, T b, T e)
+	IteratorInput(const std::string& name, T b, T e)
 		: Input(name), begin(b), end(e) {}
 	/**
 	 * Copy the data into the buffer.

--- a/parser.hh
+++ b/parser.hh
@@ -183,7 +183,7 @@ class Input
 	/**
 	 * Returns a user-meaningful name (typically a filename).
 	 */
-	std::string name() const
+	const std::string& name() const
 	{
 		return user_name;
 	}


### PR DESCRIPTION
In a multi-file project, it's handy for a `ParserPosition` to know what
file the error was located in, not just the line and column. This commit
adds a string `user_name` to the `Input` class, which is then used by
`ParserPosition` objects. This name can be any user-meaningful name, but
it probably ought to be a filename whenever possible.