### PR TITLE
Allow parse_procs to be bound by subclasses.

### DIFF
--- a/ast.hh
+++ b/ast.hh
@@ -496,15 +496,14 @@ class ASTParserDelegate : ParserDelegate
 	 * The map from rules to parsing handlers.
 	 */
 	std::unordered_map<const Rule*, parse_proc> handlers;
+	protected:
 	/**
-	 * Registers a callback in this delegate.  This should only be called from
-	 * the `static` version of this function.
+	 * Registers a callback in this delegate.
 	 */
 	void set_parse_proc(const Rule &r, parse_proc p);
 	/**
 	 * Registers a callback for a specific rule in the instance of this class
-	 * currently under construction in this thread.  This should only ever be
-	 * called by `BindAST` instances.
+	 * currently under construction in this thread.
 	 */
 	static void bind_parse_proc(const Rule &r, parse_proc p);
 	public:


### PR DESCRIPTION
The `BindAST` template requires that AST classes have default constructors
and a `construct` method for post-construction initialization. This is fine
for some use cases, but it precludes effective patterns like
immutable fields and factory methods.

The precise details of how a language's AST nodes are constructed are
highly variable, so rather than adding more variants of `BindAST` to
Pegmatite itself, this commit makes `ASTParserDelegate::set_parse_proc`
and `bind_parse_proc` visible to subclasses of `ASTParserDelegate`.
That way, a language's parser delegate can implement its own binding logic.