### PR TITLE
Add InputRange::str() method.

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <cassert>
 #include <stdexcept>
+#include <sstream>
 #include <regex>
 #include <unordered_map>
 #include <unordered_set>
@@ -1513,6 +1514,18 @@ ExprPtr operator !(const ExprPtr &e)
 	@param e end position.
  */
 InputRange::InputRange(const ParserPosition &b, const ParserPosition &e) : start(b), finish(e) { }
+
+std::string InputRange::str() const
+{
+	std::stringstream s;
+
+	for (char c : *this)
+	{
+		s << c;
+	}
+
+	return s.str();
+}
 
 
 /** constructor.

--- a/parser.hh
+++ b/parser.hh
@@ -443,6 +443,10 @@ public:
 	 * Iterator to the end of the input range.
 	 */
 	Input::iterator end() const { return finish.it; };
+	/**
+	 * Convert this range to a std::string.
+	 */
+	std::string str() const;
 };
 
 


### PR DESCRIPTION
This operation (construct a `std::stringstream`, feed characters into it,
turn them into a `std::string`) seems to be pretty common, so implement
it in one place instead of many.