### PR TITLE
Change C-style to C++ casts.

### DIFF
--- a/ast.hh
+++ b/ast.hh
@@ -309,7 +309,7 @@ public:
 
 	explicit operator bool() const noexcept
 	{
-		return (bool)ptr;
+		return static_cast<bool>(ptr);
 	}
 
 	/**

--- a/parser.cc
+++ b/parser.cc
@@ -401,10 +401,10 @@ public:
 	{
 		assert(min >= 0);
 		assert(min <= max);
-		mSetExpr.resize((size_t)max + 1U);
+		mSetExpr.resize(static_cast<size_t>(max) + 1U);
 		for(; min <= max; ++min)
 		{
-			mSetExpr[(size_t)min] = true;
+			mSetExpr[static_cast<size_t>(min)] = true;
 		}
 	}
 
@@ -476,7 +476,7 @@ class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Ou
 		public:
 		inline IteratorAdaptor(Src src) : s(src) {}
 		inline IteratorAdaptor() {}
-		inline Out operator*() const { return (Out)*s; }
+		inline Out operator*() const { return static_cast<Out>(*s); }
 		inline IteratorAdaptor &operator++()
 		{
 			++s;
@@ -1138,7 +1138,7 @@ void StringExpr::dump() const
 	fprintf(stderr, "\"");
 	for (int c : characters)
 	{
-		fprintf(stderr, "%c", (char)c);
+		fprintf(stderr, "%c", static_cast<char>(c));
 	}
 	fprintf(stderr, "\"");
 }
@@ -1737,7 +1737,7 @@ bool CharacterExpr::parse_term(Context &con) const
 }
 void CharacterExpr::dump() const
 {
-	fprintf(stderr, "'%c'", (char)character);
+	fprintf(stderr, "'%c'", static_cast<char>(character));
 }
 
 ExprPtr CharacterExpr::operator-(const CharacterExpr &other)

--- a/parser.hh
+++ b/parser.hh
@@ -362,7 +362,7 @@ class IteratorInput : public Input
 	 */
 	bool fillBuffer(Index start, Index &length, char32_t *&b) override
 	{
-		if (start > (Index)(end-begin))
+		if (start > static_cast<Index>(end-begin))
 		{
 			length = 0;
 			return false;
@@ -370,7 +370,7 @@ class IteratorInput : public Input
 		Index copied = 0;
 		for (T i=(begin+start) ; (i != end) && (copied < length) ; ++i)
 		{
-			b[copied++] = (char32_t)(*i);
+			b[copied++] = static_cast<char32_t>(*i);
 		}
 		length = copied;
 		return true;
@@ -378,7 +378,7 @@ class IteratorInput : public Input
 	/**
 	 * Returns the size of the string.
 	 */
-	Index size() const override { return (Index)(end - begin); }
+	Index size() const override { return static_cast<Index>(end - begin); }
 };
 
 
@@ -793,7 +793,7 @@ template <class T> T &operator << (T &stream, const InputRange &ir)
 {
 	for(auto c : ir)
 	{
-		stream << (typename T::char_type)c;
+		stream << static_cast<typename T::char_type>(c);
 	}
 	return stream;
 }


### PR DESCRIPTION
This makes Clang happier with lots of warnings enabled (specifically
`-Wold-style-casts`, which is included in `-Weverything`).