### PR TITLE
Fix more warnings.

### DIFF
--- a/ast.cc
+++ b/ast.cc
@@ -110,11 +110,11 @@ parse_proc ASTParserDelegate::get_parse_proc(const Rule &r) const
 	@return pointer to AST node created, or null if there was an Error.
 		The return object must be deleted by the caller.
  */
-std::unique_ptr<ASTNode> parse(Input &i, const Rule &g, const Rule &ws,
+std::unique_ptr<ASTNode> parse(Input &input, const Rule &g, const Rule &ws,
                                ErrorList &el, const ParserDelegate &d)
 {
 	ASTStack st;
-	if (!parse(i, g, ws, el, d, &st)) return 0;
+	if (!parse(input, g, ws, el, d, &st)) return 0;
 	if (st.size() > 1)
 	{
 		int i = 0;

--- a/ast.cc
+++ b/ast.cc
@@ -48,6 +48,15 @@ __thread pegmatite::ASTParserDelegate *currentParserDelegate;
 
 namespace pegmatite {
 
+/**
+ * Out-of-line virtual destructor forces vtable to be emitted in this
+ * translation unit only.
+ */
+ASTNode::~ASTNode()
+{
+}
+
+
 /** sets the container under construction to be this.
  */
 ASTContainer::ASTContainer()

--- a/ast.hh
+++ b/ast.hh
@@ -43,7 +43,7 @@ template <class T> void debug_log(const char *msg, int depth, T *obj)
 {
 #ifdef DEBUG_AST_CONSTRUCTION
 	const char *mangled = typeid(*obj).name();
-	char *buffer = (char*)malloc(strlen(mangled));
+	char *buffer = static_cast<char*>(malloc(strlen(mangled)));
 	int err;
 	size_t s;
 	char *demangled = abi::__cxa_demangle(mangled, buffer, &s,
@@ -51,7 +51,7 @@ template <class T> void debug_log(const char *msg, int depth, T *obj)
 	fprintf(stderr, "[%d] %s %s (%p) off the AST stack\n",
 			depth, msg,
 		demangled ? demangled : mangled, obj);
-	free((void*)(demangled ? demangled : buffer));
+	free(static_cast<void*>(demangled ? demangled : buffer));
 #endif // DEBUG_AST_CONSTRUCTION
 }
 

--- a/ast.hh
+++ b/ast.hh
@@ -557,10 +557,10 @@ public:
 			{
 				ASTStack *st = reinterpret_cast<ASTStack *>(d);
 				T *obj = new T();
-				InputRange input(b,e);
+				InputRange range(b,e);
 				debug_log("Constructing", st->size(), obj);
-				obj->construct(input, *st);
-				st->push_back(std::make_pair(input, std::unique_ptr<ASTNode>(obj)));
+				obj->construct(range, *st);
+				st->push_back(std::make_pair(range, std::unique_ptr<ASTNode>(obj)));
 				debug_log("Constructed", st->size()-1, obj);
 			});
 	}

--- a/ast.hh
+++ b/ast.hh
@@ -108,8 +108,10 @@ public:
 	
 	/**
 	 * Destructor does nothing, virtual for subclasses to use.
+	 * Defined out-of-line to avoid emitting vtables in every translation
+	 * unit that includes this header.
 	 */
-	virtual ~ASTNode() {}
+	virtual ~ASTNode();
 	
 	/**
 	 * Returns the parent of this AST node, or `nullptr` if there isn't one

--- a/ast.hh
+++ b/ast.hh
@@ -555,10 +555,10 @@ public:
 			{
 				ASTStack *st = reinterpret_cast<ASTStack *>(d);
 				T *obj = new T();
-				InputRange r(b,e);
+				InputRange input(b,e);
 				debug_log("Constructing", st->size(), obj);
-				obj->construct(r, *st);
-				st->push_back(std::make_pair(r, std::unique_ptr<ASTNode>(obj)));
+				obj->construct(input, *st);
+				st->push_back(std::make_pair(input, std::unique_ptr<ASTNode>(obj)));
 				debug_log("Constructed", st->size()-1, obj);
 			});
 	}

--- a/parser.cc
+++ b/parser.cc
@@ -116,6 +116,14 @@ namespace pegmatite
 {
 
 /**
+ * Out-of-line virtual destructor forces vtable to be emitted in this
+ * translation unit only.
+ */
+Expr::~Expr()
+{
+}
+
+/**
  * Character expression, matches a single character.
  */
 class CharacterExpr : public Expr

--- a/parser.cc
+++ b/parser.cc
@@ -491,7 +491,7 @@ class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Ou
 			++s;
 			return *this;
 		}
-		inline IteratorAdaptor<Src, Out,In> operator++(int inc)
+		inline IteratorAdaptor<Src, Out,In> operator++(int /*dummy*/)
 		{
 			auto copy = *this;
 			s++;

--- a/parser.cc
+++ b/parser.cc
@@ -1679,10 +1679,12 @@ ExprPtr debug(std::function<void()> fn)
 {
 	return ExprPtr(new DebugExpr(fn));
 }
+#ifdef DEBUG_PARSING
 ExprPtr trace_debug(const char *msg, const ExprPtr e)
 {
 	return ExprPtr(new TraceExpr(msg, e));
 }
+#endif
 
 
 /** parses the given input.

--- a/parser.cc
+++ b/parser.cc
@@ -317,8 +317,8 @@ private:
 		MatchMode mode;
 
 		//constructor
-		RuleState(size_t ParserPosition = Input::npos, MatchMode mode = PARSE) :
-			position(ParserPosition), mode(mode) {}
+		RuleState(size_t ParserPosition = Input::npos, MatchMode m = PARSE) :
+			position(ParserPosition), mode(m) {}
 	};
 	//parse non-term rule.
 	//parse term rule.
@@ -641,10 +641,10 @@ public:
 		for(;;)
 		{
 			con.parse_ws();
-			ParsingState st(con);
+			ParsingState s(con);
 			if (!expr->parse_non_term(con))
 			{
-				con.restore(st);
+				con.restore(s);
 				break;
 			}
 		}
@@ -666,10 +666,10 @@ public:
 		//parse the rest until no more parsing is possible
 		for(;;)
 		{
-			ParsingState st(con);
+			ParsingState s(con);
 			if (!expr->parse_term(con))
 			{
-				con.restore(st);
+				con.restore(s);
 				break;
 			}
 		}
@@ -877,8 +877,8 @@ public:
 class BinaryExpr : public Expr
 {
 public:
-	BinaryExpr(const ExprPtr &left, const ExprPtr &right) :
-		left(left), right(right) { }
+	BinaryExpr(const ExprPtr &l, const ExprPtr &r) :
+		left(l), right(r) { }
 protected:
 	const ExprPtr left, right;
 };

--- a/parser.cc
+++ b/parser.cc
@@ -107,7 +107,7 @@ private:
 	/**
 	 * The characters that this expression will match.
 	 */
-	std::vector<int> characters;
+	std::vector<char32_t> characters;
 };
 
 
@@ -131,12 +131,12 @@ class CharacterExpr : public Expr
 	/**
 	 * The character that will be recognised by this expression.
 	 */
-	int character;
+	char32_t character;
 public:
 	/**
 	 * Constructs a character expression from the specified integer.
 	 */
-	CharacterExpr(int c) : character(c) {}
+	CharacterExpr(char32_t c) : character(c) {}
 	virtual bool parse_non_term(Context &con) const;
 	virtual bool parse_term(Context &con) const;
 	virtual void dump() const;
@@ -149,10 +149,14 @@ public:
 	 * Returns a range expression that recognises characters in the specified
 	 * range.
 	 */
-	ExprPtr operator-(int other);
+	ExprPtr operator-(char32_t other);
 };
 
 CharacterExprPtr operator "" _E(const char x)
+{
+	return CharacterExprPtr(new CharacterExpr(static_cast<char32_t>(x)));
+}
+CharacterExprPtr operator "" _E(const char32_t x)
 {
 	return CharacterExprPtr(new CharacterExpr(x));
 }
@@ -168,7 +172,7 @@ ExprPtr operator-(const CharacterExprPtr &left, const CharacterExprPtr &right)
 {
 	return (*left) - (*right);
 }
-ExprPtr operator-(const CharacterExprPtr &left, int right)
+ExprPtr operator-(const CharacterExprPtr &left, char32_t right)
 {
 	return (*left) - right;
 }
@@ -406,7 +410,7 @@ public:
 	}
 
 	//constructor from range.
-	SetExpr(int min, int max)
+	SetExpr(char32_t min, char32_t max)
 	{
 		assert(min >= 0);
 		assert(min <= max);
@@ -1121,9 +1125,9 @@ ParsingState::ParsingState(Context &con) :
 }
 
 static inline bool parseString(Context &con,
-                               const std::vector<int> &characters)
+                               const std::vector<char32_t> &characters)
 {
-	for (int c : characters)
+	for (char32_t c : characters)
 	{
 		if (con.end() || con.symbol() != c)
 		{
@@ -1145,7 +1149,7 @@ bool StringExpr::parse_term(Context &con) const
 void StringExpr::dump() const
 {
 	fprintf(stderr, "\"");
-	for (int c : characters)
+	for (char32_t c : characters)
 	{
 		fprintf(stderr, "%c", static_cast<char>(c));
 	}
@@ -1347,7 +1351,7 @@ static ParserPosition _next_pos(const ParserPosition &p)
 static Error _syntax_Error(Context &con)
 {
 	std::string str = "syntax error: ";
-	str += *con.error_pos.it;
+	str += static_cast<char>(*con.error_pos.it);
 	return Error(con.error_pos, _next_pos(con.error_pos), ERROR_SYNTAX_ERROR);
 }
 
@@ -1635,7 +1639,7 @@ ExprPtr operator "" _R(const char *x, std::size_t len)
 	@param max max character.
 	@return an expression which parses a single character out of range.
  */
-ExprPtr range(int min, int max)
+ExprPtr range(char32_t min, char32_t max)
 {
 	return ExprPtr(new SetExpr(min, max));
 }
@@ -1733,7 +1737,7 @@ bool parse(Input &i, const Rule &g, const Rule &ws, ErrorList &el,
 
 ParserDelegate::~ParserDelegate() {}
 
-static inline bool parseCharacter(Context &con, int character)
+static inline bool parseCharacter(Context &con, char32_t character)
 {
 	if (!con.end())
 	{
@@ -1765,7 +1769,7 @@ ExprPtr CharacterExpr::operator-(const CharacterExpr &other)
 {
 	return range(character, other.character);
 }
-ExprPtr CharacterExpr::operator-(int other)
+ExprPtr CharacterExpr::operator-(char32_t other)
 {
 	return range(character, other);
 }

--- a/parser.cc
+++ b/parser.cc
@@ -1555,9 +1555,9 @@ Rule::Rule(const ExprPtr e) :
 /** constructor from rule.
 	@param r rule.
  */
-ExprPtr::ExprPtr(const char *s) : std::shared_ptr<Expr>(new StringExpr(s)) {};
-ExprPtr::ExprPtr(const char s) : std::shared_ptr<Expr>(new CharacterExpr(s)) {};
-ExprPtr::ExprPtr(const Rule &r) : std::shared_ptr<Expr>(new RuleReferenceExpr(r)) {};
+ExprPtr::ExprPtr(const char *s) : std::shared_ptr<Expr>(new StringExpr(s)) {}
+ExprPtr::ExprPtr(const char32_t s) : std::shared_ptr<Expr>(new CharacterExpr(s)) {}
+ExprPtr::ExprPtr(const Rule &r) : std::shared_ptr<Expr>(new RuleReferenceExpr(r)) {}
 
 
 /** creates a sequence of expressions.

--- a/parser.hh
+++ b/parser.hh
@@ -522,7 +522,7 @@ struct ExprPtr : public std::shared_ptr<Expr>
 	 * Construct an expression pointer wrapping a character expression created
 	 * from a character.
 	 */
-	ExprPtr(const char);
+	ExprPtr(const char32_t);
 };
 
 
@@ -648,6 +648,7 @@ inline ExprPtr operator !(const Rule &r)
 
 
 CharacterExprPtr operator "" _E(const char x);
+CharacterExprPtr operator "" _E(const char32_t x);
 /**
  * Constructs a set expression.
  */
@@ -661,7 +662,7 @@ ExprPtr operator "" _E(const char *x, std::size_t len);
  */
 ExprPtr operator "" _R(const char *x, std::size_t len);
 ExprPtr operator-(const CharacterExprPtr &left, const CharacterExprPtr &right);
-ExprPtr operator-(const CharacterExprPtr &left, int right);
+ExprPtr operator-(const CharacterExprPtr &left, char32_t right);
 
 
 /**
@@ -732,7 +733,7 @@ ExprPtr set(const wchar_t *s);
 	@param max max character.
 	@return an expression which parses a single character out of range.
  */
-ExprPtr range(int min, int max);
+ExprPtr range(char32_t min, char32_t max);
 
 
 /** creates an expression which increments the line counter

--- a/parser.hh
+++ b/parser.hh
@@ -576,8 +576,11 @@ public:
 	 * Virtual destructor for safe overloading.  Note that generally expression
 	 * objects are not meant to be deallocated, as they can be used by multiple
 	 * parsers. 
+	 *
+	 * Defined out-of-line to avoid emitting vtables in every translation
+	 * unit that includes this header.
 	 */
-	virtual ~Expr() { }
+	virtual ~Expr();
 
 	/**
 	 * Parse this expression as a non-terminal.  Non-terminals are permitted to

--- a/parser.hh
+++ b/parser.hh
@@ -438,11 +438,11 @@ public:
 	/**
 	 * Iterator to the start of the input range.
 	 */
-	Input::iterator begin() const { return start.it; };
+	Input::iterator begin() const { return start.it; }
 	/**
 	 * Iterator to the end of the input range.
 	 */
-	Input::iterator end() const { return finish.it; };
+	Input::iterator end() const { return finish.it; }
 	/**
 	 * Convert this range to a std::string.
 	 */


### PR DESCRIPTION
Deal with lots of Clang warnings, some of which are actually pretty sensible.

I can now compile cleanly with `-Weverything -Wno-c++98-compat -Wno-documentation -Wno-padded` using Clang 3.6 (er, Apple "6.1.0").