### PR TITLE
Make error reporting more flexible.

### DIFF
--- a/ast.cc
+++ b/ast.cc
@@ -114,16 +114,16 @@ parse_proc ASTParserDelegate::get_parse_proc(const Rule &r) const
 	@param i input.
 	@param g root rule of grammar.
 	@param ws whitespace rule.
-	@param el list of errors.
+	@param err callback for reporting errors.
 	@param d user data, passed to the parse procedures.
 	@return pointer to AST node created, or null if there was an Error.
 		The return object must be deleted by the caller.
  */
 std::unique_ptr<ASTNode> parse(Input &input, const Rule &g, const Rule &ws,
-                               ErrorList &el, const ParserDelegate &d)
+                               ErrorReporter &err, const ParserDelegate &d)
 {
 	ASTStack st;
-	if (!parse(input, g, ws, el, d, &st)) return 0;
+	if (!parse(input, g, ws, err, d, &st)) return 0;
 	if (st.size() > 1)
 	{
 		int i = 0;

--- a/ast.hh
+++ b/ast.hh
@@ -466,13 +466,13 @@ private:
 	@param i input.
 	@param g root rule of grammar.
 	@param ws whitespace rule.
-	@param el list of errors.
+	@param err callback for reporting errors.
 	@param d user data, passed to the parse procedures.
 	@return pointer to ast node created, or null if there was an error.
 		The return object must be deleted by the caller.
  */
 std::unique_ptr<ASTNode> parse(Input &i, const Rule &g, const Rule &ws,
-                               ErrorList &el, const ParserDelegate &d);
+                               ErrorReporter &err, const ParserDelegate &d);
 
 /**
  * A parser delegate that is responsible for creating AST nodes from the input.
@@ -525,9 +525,10 @@ class ASTParserDelegate : ParserDelegate
 	 * This function returns true on a successful parse, or false otherwise.
 	 */
 	template <class T> bool parse(Input &i, const Rule &g, const Rule &ws,
-	                              ErrorList &el, std::unique_ptr<T> &ast) const
+	                              ErrorReporter &err,
+	                              std::unique_ptr<T> &ast) const
 	{
-		std::unique_ptr<ASTNode> node = pegmatite::parse(i, g, ws, el, *this);
+		std::unique_ptr<ASTNode> node = pegmatite::parse(i, g, ws, err, *this);
 		T *n = node->get_as<T>();
 		if (n)
 		{

--- a/parser.hh
+++ b/parser.hh
@@ -461,8 +461,10 @@ struct ParserPosition
  * When constructing an AST using the AST infrastructure, this will be a lambda
  * binding the type of the AST node to create and the argument will be
  * interpreted as an AST stack.
+ *
+ * @return whether or not the procedure executed successfully
  */
-typedef std::function<void(const ParserPosition&,
+typedef std::function<bool(const ParserPosition&,
                            const ParserPosition&, void*)> parse_proc;
 
 
@@ -501,45 +503,8 @@ public:
 	std::string str() const;
 };
 
-
-///enum with error types.
-enum ERROR_TYPE
-{
-	///syntax error
-	ERROR_SYNTAX_ERROR = 1,
-
-	///invalid end of file
-	ERROR_INVALID_EOF,
-
-	///first user error
-	ERROR_USER = 100
-};
-
-
-///Error.
-class Error : public InputRange
-{
-public:
-	///type
-	int error_type;
-
-	/** constructor.
-		@param b begin position.
-		@param e end position.
-		@param t type.
-	 */
-	Error(const ParserPosition &b, const ParserPosition &e, int t);
-
-	/** compare on begin position.
-		@param e the other error to compare this with.
-		@return true if this comes before the previous error, false otherwise.
-	 */
-	bool operator < (const Error &e) const;
-};
-
-
-///type of error list.
-typedef std::list<Error> ErrorList;
+/// A function type for reporting parser errors.
+typedef std::function<void (const InputRange&, std::string)> ErrorReporter;
 
 /**
  * CharacterExpr is a concrete subclass of Expr, which is exposed to allow it to be 
@@ -836,11 +801,11 @@ struct ParserDelegate
 	@param i input.
 	@param g root rule of grammar.
 	@param ws whitespace rule.
-	@param el list of errors.
+	@param err callback used to report errors.
 	@param d user data, passed to the parse procedures.
 	@return true on parsing success, false on failure.
  */
-bool parse(Input &i, const Rule &g, const Rule &ws, ErrorList &el,
+bool parse(Input &i, const Rule &g, const Rule &ws, ErrorReporter err,
            const ParserDelegate &delegate, void *d);
 
 


### PR DESCRIPTION
Instead of committing to a particular in-memory representation for errors,
provide a function type that can be used to report errors via callback.