### PR TITLE
Refactor name-demangling into separate function.

### DIFF
--- a/ast.cc
+++ b/ast.cc
@@ -49,6 +49,22 @@ __thread pegmatite::ASTParserDelegate *currentParserDelegate;
 
 namespace pegmatite {
 
+
+std::string demangle(std::string mangled)
+{
+	int err;
+	size_t s;
+	char *buffer = static_cast<char*>(malloc(mangled.length()));
+
+	char *demangled = abi::__cxa_demangle(mangled.c_str(), buffer, &s, &err);
+	std::string result = demangled ? demangled : mangled;
+
+	free(demangled ? demangled : buffer);
+
+	return result;
+}
+
+
 /**
  * Out-of-line virtual destructor forces vtable to be emitted in this
  * translation unit only.

--- a/ast.hh
+++ b/ast.hh
@@ -39,19 +39,14 @@
 
 namespace pegmatite {
 
+std::string demangle(std::string);
+
 #ifdef DEBUG_AST_CONSTRUCTION
 template <class T> void debug_log(const char *msg, int depth, T *obj)
 {
-	const char *mangled = typeid(*obj).name();
-	char *buffer = static_cast<char*>(malloc(strlen(mangled)));
-	int err;
-	size_t s;
-	char *demangled = abi::__cxa_demangle(mangled, buffer, &s,
-		&err);
+	std::string demangled = demangle(typeid(*obj).name());
 	fprintf(stderr, "[%d] %s %s (%p) off the AST stack\n",
-			depth, msg,
-		demangled ? demangled : mangled, obj);
-	free(static_cast<void*>(demangled ? demangled : buffer));
+			depth, msg, demangled.c_str(), obj);
 }
 #else
 template <class T> void debug_log(const char *, int /* depth */, T *) {}


### PR DESCRIPTION
This will be useful elsewhere, too (e.g., when we pop the wrong type of
thing off of a stack).