### PR TITLE
Fix more warnings in calculator example.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,6 @@
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-exit-time-destructors")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables")
+endif()
+
 add_subdirectory(calculator)


### PR DESCRIPTION
These commits contain slightly more debatable fixes to warnings like `exit-time-destructor` and `weak-vtables`.