### PR TITLE
Use references to ErrorReporter again.

### DIFF
--- a/ast.cc
+++ b/ast.cc
@@ -137,7 +137,7 @@ parse_proc ASTParserDelegate::get_parse_proc(const Rule &r) const
 		The return object must be deleted by the caller.
  */
 std::unique_ptr<ASTNode> parse(Input &input, const Rule &g, const Rule &ws,
-                               ErrorReporter err, const ParserDelegate &d)
+                               ErrorReporter &err, const ParserDelegate &d)
 {
 	ASTStack st;
 	if (!parse(input, g, ws, err, d, &st)) return 0;

--- a/ast.hh
+++ b/ast.hh
@@ -492,7 +492,7 @@ private:
 		The return object must be deleted by the caller.
  */
 std::unique_ptr<ASTNode> parse(Input &i, const Rule &g, const Rule &ws,
-                               ErrorReporter err, const ParserDelegate &d);
+                               ErrorReporter &err, const ParserDelegate &d);
 
 /**
  * A parser delegate that is responsible for creating AST nodes from the input.
@@ -545,7 +545,7 @@ class ASTParserDelegate : ParserDelegate
 	 * This function returns true on a successful parse, or false otherwise.
 	 */
 	template <class T> bool parse(Input &i, const Rule &g, const Rule &ws,
-	                              ErrorReporter &err,
+	                              ErrorReporter err,
 	                              std::unique_ptr<T> &ast) const
 	{
 		std::unique_ptr<ASTNode> node = pegmatite::parse(i, g, ws, err, *this);

--- a/parser.cc
+++ b/parser.cc
@@ -1350,14 +1350,14 @@ static ParserPosition _next_pos(const ParserPosition &p)
 
 
 //get syntax error
-static void _syntax_Error(ErrorReporter err, Context &con)
+static void _syntax_Error(ErrorReporter &err, Context &con)
 {
 	err(InputRange(con.error_pos, _next_pos(con.error_pos)), "syntax error");
 }
 
 
 //get eof error
-static void _eof_Error(ErrorReporter err, Context &con)
+static void _eof_Error(ErrorReporter &err, Context &con)
 {
 	err(InputRange(con.error_pos, con.error_pos), "EOF");
 }
@@ -1752,7 +1752,7 @@ ExprPtr trace_debug(const char *msg, const ExprPtr e)
 	@param d user data, passed to the parse procedures.
 	@return true on parsing success, false on failure.
  */
-bool parse(Input &i, const Rule &g, const Rule &ws, ErrorReporter err,
+bool parse(Input &i, const Rule &g, const Rule &ws, ErrorReporter &err,
            const ParserDelegate &delegate, void *d)
 {
 	//prepare context

--- a/parser.hh
+++ b/parser.hh
@@ -808,7 +808,7 @@ struct ParserDelegate
 	@param d user data, passed to the parse procedures.
 	@return true on parsing success, false on failure.
  */
-bool parse(Input &i, const Rule &g, const Rule &ws, ErrorReporter err,
+bool parse(Input &i, const Rule &g, const Rule &ws, ErrorReporter &err,
            const ParserDelegate &delegate, void *d);
 
 


### PR DESCRIPTION
We don't actually need to make all of these copes of, in many cases, lambda
functions with captured values.