### PR TITLE
Don't abort on missing but optional values.

### DIFF
--- a/ast.hh
+++ b/ast.hh
@@ -310,6 +310,9 @@ public:
 		if ((childRange.begin() < r.begin()) ||
 			(childRange.end() > r.end()))
 		{
+			if (Optional)
+				return true;
+
 			err(childRange,
 				"Non-optional " + demangle(typeid(T).name()) + " expected.");
 			return false;


### PR DESCRIPTION
When constructing an AST element, it's possible for the next thing on the
stack to have the correct type but be in the wrong location (e.g., adjacent
to something of the same type). The comment at this location already
describes the issue, but the code always reports an error and returns false.
Before error'ing out in this way, we should check to see whether the AST
element we're looking for is optional: missing optional nodes aren't errors.