### PR TITLE
Fix a buffer overflow issue when using StringInput

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -1439,9 +1439,10 @@ bool  StringInput::fillBuffer(Index start, Index &length, char32_t *&b)
 		return false;
 	}
 	length = std::min(length, str.size() - start);
-	for (Index i=start ; i<length ; i++)
+	std::size_t j = 0;
+	for (Index i = start; i < start + length; ++i, ++j)
 	{
-		b[i] = static_cast<char32_t>(str[i]);
+		b[j] = static_cast<char32_t>(str[i]);
 	}
 	return true;
 }


### PR DESCRIPTION
Previously, parsing directly from a string (using `StringInput`) with a length greater than the buffer size (512 characters) would result in memory corruption and parsing errors.