### PR TITLE
Changes to make compile with MSVC C++17

### DIFF
--- a/ast.cc
+++ b/ast.cc
@@ -171,7 +171,7 @@ bool ASTString::construct(const pegmatite::InputRange &r, pegmatite::ASTStack &,
                           const ErrorReporter &)
 {
 	std::stringstream stream;
-	for_each(r.begin(),
+	std::for_each(r.begin(),
 	         r.end(),
 	         [&](char32_t c) {stream << static_cast<char>(c);});
 	this->std::string::operator=(stream.str());

--- a/parser.cc
+++ b/parser.cc
@@ -495,10 +495,17 @@ private:
  * appropriately).
  */
 template<typename Src, typename Out, typename In>
-class IteratorAdaptor : public std::iterator<std::bidirectional_iterator_tag, Out>
+class IteratorAdaptor
 {
 		Src s;
 		public:
+
+		typedef std::bidirectional_iterator_tag iterator_category;
+		typedef std::ptrdiff_t difference_type;
+		typedef Out value_type;
+		typedef const Out& reference;
+		typedef const Out* pointer;
+
 		inline IteratorAdaptor(Src src) : s(src) {}
 		inline IteratorAdaptor() {}
 		inline Out operator*() const { return static_cast<Out>(*s); }

--- a/parser.hh
+++ b/parser.hh
@@ -67,7 +67,7 @@ class Input
 	/**
 	 * Iterator, refers back into the input stream.
 	 */
-	class iterator : public std::iterator<std::bidirectional_iterator_tag, char32_t>
+	class iterator
 	{
 		friend Input;
 		/**
@@ -83,6 +83,13 @@ class Input
 		 */
 		inline iterator(Input *b, Index i) : buffer(b), idx(i) {}
 		public:
+
+		typedef std::bidirectional_iterator_tag iterator_category;
+		typedef std::ptrdiff_t difference_type;
+		typedef const char32_t& reference;
+		typedef const char32_t* pointer;
+		typedef char32_t value_type;
+	
 		/**
 		 * Default constructor, constructs an invalid iterator into no buffer.
 		 */


### PR DESCRIPTION
std::iterator inheritance is deprecated in C++17.  This commit changes
to using the relevant typedefs for the iterator_traits.