### PR TITLE
Fix compilation on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+cmake_policy(SET CMP0042 NEW)
 
 project(libpegmatite)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD 11)
 
-
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(CLANG_FLAGS "-Weverything -Wno-c++98-compat -Wno-padded")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")
@@ -33,11 +32,21 @@ else()
 	endif()
 endif()
 
+if (WIN32)
+  target_compile_definitions(pegmatite PUBLIC -DPEGMATITE_PLATFORM_WINDOWS)
+  target_compile_definitions(pegmatite-static PUBLIC -DPEGMATITE_PLATFORM_WINDOWS)
+elseif(UNIX)
+  target_compile_definitions(pegmatite PUBLIC -DPEGMATITE_PLATFORM_UNIX)
+  target_compile_definitions(pegmatite-static PUBLIC -DPEGMATITE_PLATFORM_UNIX)
+endif()
+
 option(USE_RTTI "Use native C++ RTTI" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 if (USE_RTTI)
-	add_definitions(-DUSE_RTTI=1)
+  target_compile_definitions(pegmatite PUBLIC -DUSE_RTTI=1)
+  target_compile_definitions(pegmatite-static PUBLIC -DUSE_RTTI=1)
 endif()
+
 if(BUILD_DOCUMENTATION)
 	FIND_PACKAGE(Doxygen)
 	if (NOT DOXYGEN_FOUND)
@@ -55,10 +64,13 @@ endif()
 
 option(BUILD_TRACING "Build with debug parse tracing support" OFF)
 if (BUILD_TRACING)
-	add_definitions("-D DEBUG_PARSING")
+  target_compile_definitions(pegmatite PUBLIC -DDEBUG_PARSING)
+  target_compile_definitions(pegmatite-static PUBLIC -DDEBUG_PARSING)
 endif()
 
-include_directories(.)
+target_include_directories(pegmatite PUBLIC .)
+target_include_directories(pegmatite-static PUBLIC .)
+
 option(BUILD_EXAMPLES "Build examples" OFF)
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)

--- a/ast.cc
+++ b/ast.cc
@@ -30,6 +30,9 @@
 #include <cstdlib>
 #include "ast.hh"
 
+#ifdef PEGMATITE_PLATFORM_UNIX
+#include <cxxabi.h>
+#endif
 
 namespace {
 /**
@@ -56,7 +59,7 @@ std::string demangle(std::string mangled)
 	char *buffer = static_cast<char*>(malloc(mangled.length() + 1));
 
 	char *demangled = 
-#ifdef __unix__
+#ifdef PEGMATITE_PLATFORM_UNIX
 		abi::__cxa_demangle(mangled.c_str(), buffer, &s, &err);
 #else
 		nullptr;

--- a/ast.hh
+++ b/ast.hh
@@ -36,9 +36,6 @@
 #include <unordered_map>
 #include <sstream>
 #include <memory>
-#ifdef __unix__
-#include <cxxabi.h>
-#endif
 #include "parser.hh"
 
 

--- a/parser.cc
+++ b/parser.cc
@@ -37,7 +37,7 @@
 #include <unordered_set>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifdef __unix__
+#ifdef PEGMATITE_PLATFORM_UNIX
 #include <sys/uio.h>
 #include <unistd.h>
 #endif
@@ -1468,7 +1468,7 @@ Input::Index StringInput::size() const
 
 const std::size_t Input::static_buffer_size;
 
-#ifdef __unix__
+#ifdef PEGMATITE_PLATFORM_UNIX
 AsciiFileInput::AsciiFileInput(int file, const std::string& name)
 	: Input(name), fd(file)
 {

--- a/parser.cc
+++ b/parser.cc
@@ -1466,6 +1466,8 @@ Input::Index StringInput::size() const
 	return str.size();
 }
 
+const std::size_t Input::static_buffer_size;
+
 #ifdef __unix__
 AsciiFileInput::AsciiFileInput(int file, const std::string& name)
 	: Input(name), fd(file)
@@ -1482,7 +1484,6 @@ AsciiFileInput::AsciiFileInput(int file, const std::string& name)
 	}
 }
 
-const std::size_t Input::static_buffer_size;
 bool AsciiFileInput::fillBuffer(Index start, Index &length, char32_t *&b)
 {
 	if (start > file_size)

--- a/parser.hh
+++ b/parser.hh
@@ -316,7 +316,7 @@ class UnicodeVectorInput : public Input
 	Index size() const override;
 };
 
-#ifdef __unix__
+#ifdef PEGMATITE_PLATFORM_UNIX
 /**
  * A concrete `Input` class that wraps a file.  The file is assumed to be in
  * ASCII.  Note that this does *NOT* include UTF-8 unless it is restricted to


### PR DESCRIPTION
- Move `static_buffer_size` outside of UNIX ifdef.
- Fix platform detection by using CMake to do it.
- Enable CMake policy CMP0042 to silence warning.
