### PR TITLE
Pegmatite has two tracing options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,12 @@ if (BUILD_TRACING)
   target_compile_definitions(pegmatite-static PUBLIC -DDEBUG_PARSING)
 endif()
 
+option(BUILD_AST_TRACING "Build with debug AST construction tracing support" OFF)
+if (BUILD_AST_TRACING)
+  target_compile_definitions(pegmatite PUBLIC -DDEBUG_AST_CONSTRUCTION)
+  target_compile_definitions(pegmatite-static PUBLIC -DDEBUG_AST_CONSTRUCTION)
+endif()
+
 target_include_directories(pegmatite PUBLIC .)
 target_include_directories(pegmatite-static PUBLIC .)
 


### PR DESCRIPTION
One for debugging the parsing, and one for debugging building the AST.
The commit makes the AST construction exposed to CMake.