### PR TITLE
Refactor cmake to not always build shared library

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,46 @@
+name: CMake
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C $BUILD_TYPE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,18 +2,17 @@ name: CMake
 
 on: [push]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        type: [Release, Debug]
     steps:
     - uses: actions/checkout@v2
 
@@ -30,17 +29,17 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DBUILD_EXAMPLES=On
 
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
-
+      run: cmake --build . --config ${{ matrix.type }}
+      
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C ${{ matrix.type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_policy(SET CMP0042 NEW)
 
 project(libpegmatite)
 
+if (WIN32)
+	# No support on Windows for a shared library.
+	set(BUILD_SHARED_LIB OFF)
+else()
+	option(BUILD_SHARED_LIB "Build shared library" ON)
+endif()
+
 set(libpegmatite 0.1)
 
 set(libpegmatite_CXX_SRCS
@@ -10,8 +17,35 @@ set(libpegmatite_CXX_SRCS
 	parser.cc
 )
 
-add_library(pegmatite SHARED ${libpegmatite_CXX_SRCS})
+option(USE_RTTI "Use native C++ RTTI" ON)
+option(BUILD_TRACING "Build with debug parse tracing support" OFF)
+option(BUILD_AST_TRACING "Build with debug AST construction tracing support" OFF)
+
+macro(set_options target)
+	if (WIN32)
+		target_compile_definitions(${target} PUBLIC -DPEGMATITE_PLATFORM_WINDOWS)
+	elseif(UNIX)
+		target_compile_definitions(${target} PUBLIC -DPEGMATITE_PLATFORM_UNIX)
+	endif()
+	if (USE_RTTI)
+		target_compile_definitions(${target} PUBLIC -DUSE_RTTI=1)
+	endif ()
+	if (BUILD_TRACING)
+		target_compile_definitions(${target} PUBLIC -DDEBUG_PARSING)
+	endif()
+	if (BUILD_AST_TRACING)
+		target_compile_definitions(${target} PUBLIC -DDEBUG_AST_CONSTRUCTION)
+	endif()
+	target_include_directories(${target} PUBLIC .)
+endmacro()
+
+if (BUILD_SHARED_LIB)
+	add_library(pegmatite SHARED ${libpegmatite_CXX_SRCS})
+	set_options(pegmatite)
+endif()
+
 add_library(pegmatite-static STATIC ${libpegmatite_CXX_SRCS})
+set_options(pegmatite-static)
 set_target_properties(pegmatite-static PROPERTIES
 	POSITION_INDEPENDENT_CODE true
 	OUTPUT_NAME "pegmatite")
@@ -33,21 +67,7 @@ else()
 	endif()
 endif()
 
-if (WIN32)
-  target_compile_definitions(pegmatite PUBLIC -DPEGMATITE_PLATFORM_WINDOWS)
-  target_compile_definitions(pegmatite-static PUBLIC -DPEGMATITE_PLATFORM_WINDOWS)
-elseif(UNIX)
-  target_compile_definitions(pegmatite PUBLIC -DPEGMATITE_PLATFORM_UNIX)
-  target_compile_definitions(pegmatite-static PUBLIC -DPEGMATITE_PLATFORM_UNIX)
-endif()
-
-option(USE_RTTI "Use native C++ RTTI" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
-if (USE_RTTI)
-  target_compile_definitions(pegmatite PUBLIC -DUSE_RTTI=1)
-  target_compile_definitions(pegmatite-static PUBLIC -DUSE_RTTI=1)
-endif()
-
 if(BUILD_DOCUMENTATION)
 	FIND_PACKAGE(Doxygen)
 	if (NOT DOXYGEN_FOUND)
@@ -62,21 +82,6 @@ if(BUILD_DOCUMENTATION)
 	                   COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
 	                   SOURCES ${PROJECT_BINARY_DIR}/Doxyfile)
 endif()
-
-option(BUILD_TRACING "Build with debug parse tracing support" OFF)
-if (BUILD_TRACING)
-  target_compile_definitions(pegmatite PUBLIC -DDEBUG_PARSING)
-  target_compile_definitions(pegmatite-static PUBLIC -DDEBUG_PARSING)
-endif()
-
-option(BUILD_AST_TRACING "Build with debug AST construction tracing support" OFF)
-if (BUILD_AST_TRACING)
-  target_compile_definitions(pegmatite PUBLIC -DDEBUG_AST_CONSTRUCTION)
-  target_compile_definitions(pegmatite-static PUBLIC -DDEBUG_AST_CONSTRUCTION)
-endif()
-
-target_include_directories(pegmatite PUBLIC .)
-target_include_directories(pegmatite-static PUBLIC .)
 
 option(BUILD_EXAMPLES "Build examples" OFF)
 if(BUILD_EXAMPLES)

--- a/ast.hh
+++ b/ast.hh
@@ -274,7 +274,7 @@ template<typename T>
 T& constructValue(const pegmatite::InputRange &r, T& value)
 {
 	std::stringstream stream;
-	for_each(r.begin(), r.end(), [&](char c) {stream << c;});
+	std::for_each(r.begin(), r.end(), [&](char c) {stream << c;});
 	stream >> value;
 	return value;
 }

--- a/ast.hh
+++ b/ast.hh
@@ -311,7 +311,7 @@ std::pair<bool, std::unique_ptr<T>> popFromASTStack(const InputRange &r,
 
 	//get the object
 	T *obj = node->get_as<T>();
-	if (obj == nullptr and not Optional)
+	if ((obj == nullptr) && !(Optional))
 	{
 		err(childRange,
 			"Expected " + demangle(typeid(T).name())
@@ -555,7 +555,7 @@ public:
 				ASTStack *st = reinterpret_cast<ASTStack *>(d);
 				T *obj = new T();
 				debug_log("Constructing", st->size(), obj);
-				if (not obj->construct(range, *st, err))
+				if (!(obj->construct(range, *st, err)))
 				{
 					debug_log("Failed", st->size(), obj);
 					return false;


### PR DESCRIPTION
This no longer builds the shared library on Windows.  The naming causes a clash between the `lib` file for the static library, and the stub lib for the dynamic library.

Builds on top of #37.